### PR TITLE
Overhaul

### DIFF
--- a/Kubernetes-Resources/job.yaml
+++ b/Kubernetes-Resources/job.yaml
@@ -15,6 +15,8 @@ spec:
         securityContext:
           privileged: True
         env:
+        - name: LOG_LEVEL
+          value: "INFO"
         - name: SNYK_TOKEN
           valueFrom:
             secretKeyRef:

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,25 @@
+import logging.config
+from pythonjsonlogger import jsonlogger
+import os
+
+LOG_LEVEL = os.getenv("LOG_LEVEL")
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "json": {
+            "format": "%(asctime)s %(levelname)s %(message)s",
+            "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
+        }
+    },
+    "handlers": {
+        "stdout": {
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+            "formatter": "json",
+        }
+    },
+    "loggers": {"": {"handlers": ["stdout"], "level": LOG_LEVEL}},
+}
+logging.config.dictConfig(LOGGING)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,13 @@ idna==3.7
 kubernetes==29.0.0
 oauthlib==3.2.2
 pyasn1==0.6.0
-pyasn1_modules==0.4.0
+pyasn1-modules==0.4.0
 python-dateutil==2.9.0.post0
+python-json-logger==2.0.7
 PyYAML==6.0.1
-requests==2.32.0
+requests==2.32.1
 requests-oauthlib==2.0.0
 rsa==4.9
 six==1.16.0
 urllib3==2.2.1
-websocket-client==1.7.0
+websocket-client==1.8.0


### PR DESCRIPTION
- Added proper logging using a logger package instead of print

- Added LOG_LEVEL flag to the Job YAML

- Re architected the script to drop the projects endpoint and instead use the container endpoint based on imageID that we get when downloading the image.

- Due to the above change, modified the workflow to scan after each image we identify as a gap. Now we download each image, check the imageID against Snyk, then scan that image and remove it from the container. Without this, the docker cache would certainly fill up for large deployments.